### PR TITLE
[Lumberjack-2-zef-install-test-failure] Fixed tests so as to have the…

### DIFF
--- a/t/060-dispatcher-console.t
+++ b/t/060-dispatcher-console.t
@@ -38,64 +38,64 @@ my $banana = Banana.new;
 
 lives-ok { $banana.do-trace }, "trace";
 
-like $hijack.Str, /'[Trace] Banana do-trace : trace message'/, "got expected text";
+like $hijack.Str, /'[Trace] Banana log : trace message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-debug }, "debug";
 
-like $hijack.Str, /'[Debug] Banana do-debug : debug message'/, "got expected text";
+like $hijack.Str, /'[Debug] Banana log : debug message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-info }, "info";
 
-like $hijack.Str, /'[Info] Banana do-info : info message'/, "got expected text";
+like $hijack.Str, /'[Info] Banana log : info message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-warn }, "warn";
 
-like $hijack.Str, /'[Warn] Banana do-warn : warn message'/, "got expected text";
+like $hijack.Str, /'[Warn] Banana log : warn message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-error }, "error";
 
-like $hijack.Str, /'[Error] Banana do-error : error message'/, "got expected text";
+like $hijack.Str, /'[Error] Banana log : error message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-fatal }, "fatal";
 
-like $hijack.Str, /'[Fatal] Banana do-fatal : fatal message'/, "got expected text";
+like $hijack.Str, /'[Fatal] Banana log : fatal message'/, "got expected text";
 $hijack.data = ();
 
 Lumberjack.dispatchers = ( Lumberjack::Dispatcher::Console.new(:colour));
 
 lives-ok { $banana.do-trace }, "trace with colour";
 
-like $hijack.Str, /'[Trace] Banana do-trace : trace message'/, "got expected text";
+like $hijack.Str, /'[Trace] Banana log : trace message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-debug }, "debug with colour";
 
-like $hijack.Str, /'[Debug] Banana do-debug : debug message'/, "got expected text";
+like $hijack.Str, /'[Debug] Banana log : debug message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-info }, "info with colour";
 
-like $hijack.Str, /'[Info] Banana do-info : info message'/, "got expected text";
+like $hijack.Str, /'[Info] Banana log : info message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-warn }, "warn with colour";
 
-like $hijack.Str, /'[Warn] Banana do-warn : warn message'/, "got expected text";
+like $hijack.Str, /'[Warn] Banana log : warn message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-error }, "error with colour";
 
-like $hijack.Str, /'[Error] Banana do-error : error message'/, "got expected text";
+like $hijack.Str, /'[Error] Banana log : error message'/, "got expected text";
 $hijack.data = ();
 
 lives-ok { $banana.do-fatal }, "fatal with colour";
 
-like $hijack.Str, /'[Fatal] Banana do-fatal : fatal message'/, "got expected text";
+like $hijack.Str, /'[Fatal] Banana log : fatal message'/, "got expected text";
 $hijack.data = ();
 
 done-testing;

--- a/t/070-dispatcher-file.t
+++ b/t/070-dispatcher-file.t
@@ -60,12 +60,12 @@ my $fh = $file.open(:r);
 
 my $content = $fh.slurp-rest;
 
-like $content, /'[Trace] Banana do-trace : trace message'/, "got expected text for trace";
-like $content, /'[Debug] Banana do-debug : debug message'/, "got expected text for debug";
-like $content, /'[Info] Banana do-info : info message'/, "got expected text for info";
-like $content, /'[Warn] Banana do-warn : warn message'/, "got expected text for warn";
-like $content, /'[Error] Banana do-error : error message'/, "got expected text for error";
-like $content, /'[Fatal] Banana do-fatal : fatal message'/, "got expected text for fatal";
+like $content, /'[Trace] Banana log : trace message'/, "got expected text for trace";
+like $content, /'[Debug] Banana log : debug message'/, "got expected text for debug";
+like $content, /'[Info] Banana log : info message'/, "got expected text for info";
+like $content, /'[Warn] Banana log : warn message'/, "got expected text for warn";
+like $content, /'[Error] Banana log : error message'/, "got expected text for error";
+like $content, /'[Fatal] Banana log : fatal message'/, "got expected text for fatal";
 
 
 done-testing;


### PR DESCRIPTION
`[Lumberjack-2-zef-install-test-failure] Fixed tests so as to have them pass.`

I'm not entirely sure about the design decisions regarding the format of the log messages, however, I feel like this would work too: you can tell what level the message was from the `[Level]` thing, without needing to have another part like `do-level`. IMO changing the tests, and not the format (however that one may be defined, I didn't look), seems fine.