### PR TITLE
Fix test failing on rakudo 2021.04

### DIFF
--- a/lib/Lumberjack.pm
+++ b/lib/Lumberjack.pm
@@ -831,7 +831,7 @@ class Lumberjack {
     }
 
     sub default-callframes( --> Int) {
-        4;
+        3;
     }
 
     class Dispatcher::Console does Dispatcher {


### PR DESCRIPTION
Rakudo commit https://github.com/rakudo/rakudo/commit/2e79780e4aa17262fe4774c61fd45b775c3087fb changed the way backtraces were generated. Instead of throwing an exception in a thunk (which is its own call frame), we can get a backtrace for the current frame directly. The reason for this change is not just better performance, but more consistent results. Inlining by the VM's specializer could remove the thunk, thus sometimes we would get a backtrace with it and later on get backtraces without this call frame.

Due to the inlining issue, the magic number 4 has not been correct in all cases before. It would work for a few calls but in long running processes where the log method was called often enough (a few 100 times), the specializer would inline the try thunk and Lumberjack would report the wrong call frame. The new mechanism is safe from this effect and backtraces are always consistent regardless of frames getting inlined.

Note that while JVM has adopted the same semantics as MoarVM, on the JS backend there's still an additional call frame.